### PR TITLE
added 'viewpoint feature' to archive player

### DIFF
--- a/share/html/js/archive_player.coffee
+++ b/share/html/js/archive_player.coffee
@@ -22,6 +22,7 @@ BAKAZE_TO_STR =
 kyokus = []
 currentKyokuId = 0
 currentActionId = 0
+currentViewpoint = 0
 playerInfos = [{}, {}, {}, {}]
 
 parsePai = (pai) ->
@@ -272,9 +273,14 @@ renderAction = (action) ->
   kyoku = getCurrentKyoku()
   for i in [0...4]
     player = action.board.players[i]
-    view = Dytem.players.at(i)
+    view = Dytem.players.at((i-currentViewpoint+4)%4)
     infoView = Dytem.playerInfos.at(i)
     infoView.score.text(player.score)
+    if i == currentViewpoint
+      infoView.viewpoint.text("+")
+    else
+      infoView.viewpoint.text("")
+
     if !player.tehais
       renderPais([], view.tehais)
       view.tsumoPai.hide()
@@ -353,7 +359,11 @@ $ ->
     currentKyokuId = parseInt($("#kyokuSelector").val())
     currentActionId = 0
     renderCurrentAction()
-  
+
+  $("#viewpoint-button").click ->
+    currentViewpoint = (currentViewpoint + 1) % 4
+    renderCurrentAction()
+
   for action in allActions
     loadAction(action)
 

--- a/share/html/views/archive_player.erb
+++ b/share/html/views/archive_player.erb
@@ -49,10 +49,19 @@
       <button id="go-button">Go</button>
     </div>
     <table border="0">
+      <tr id="playerInfosHeader">
+        <th id="playerInfosHeader.index">i</th>
+        <th id="playerInfosHeader.name">name</th>
+        <th id="playerInfosHeader.score">score</th>
+        <th id="playerInfosHeader.viewpoint">
+          <button id="viewpoint-button">V</button>
+        </th>
+      </tr>
       <tr id="playerInfos" class="repeated">
         <td id="playerInfos.index"></td>
         <td id="playerInfos.name"></td>
         <td id="playerInfos.score"></td>
+        <td id="playerInfos.viewpoint"></td>
       </tr>
     </table>
     <div id="action-label"></div>


### PR DESCRIPTION
archive playerに視点変更機能を付けました。
自分のAIを見たい時に少し便利です。

「V」ボタンを押すと、視点が下家に切り替わります。
現在の視点を「+」で表示しています。

<img src="http://dl.dropbox.com/u/1344248/github/archivePlayerViewpoint_1.png" width ="300">
<img src="http://dl.dropbox.com/u/1344248/github/archivePlayerViewpoint_2.png" width ="300">
<img src="http://dl.dropbox.com/u/1344248/github/archivePlayerViewpoint_3.png" width ="300">
<img src="http://dl.dropbox.com/u/1344248/github/archivePlayerViewpoint_4.png" width ="300">
